### PR TITLE
Create annotations from highlights

### DIFF
--- a/rmrl/annotation.py
+++ b/rmrl/annotation.py
@@ -1,0 +1,128 @@
+# Copyright 2021 Ben Rush 
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+class Point:
+    def __init__(self, x: float, y: float):
+        self.x = x
+        self.y = y
+    
+    def toList(self) -> list:
+        return [self.x, self.y]
+
+class Rect:
+    """
+    From PDF spec:
+    a specific array object used to describe locations on a page and 
+    bounding boxes for a variety of objects and written as an array 
+    of four numbers giving the coordinates of a pair of diagonally
+    opposite corners, typically in the form [ll.x, ll.y, ur.x, ur.x]
+    """
+
+    def __init__(self, ll: Point, ur: Point):
+        self.ll = ll
+        self.ur = ur
+
+    def intersects(self, rectB: Rect) -> bool:
+        # To check if either rectangle is actually a line
+        # For example  :  l1 ={-1,0}  r1={1,1}  l2={0,-1}  r2={0,1}
+        
+        if (self.ll.x == self.ur.x or self.ll.y == self.ur.y or rectB.ll.x == rectB.ur.x or rectB.ll.y == rectB.ur.y):
+            # the line cannot have positive overlap
+            return False
+        
+        
+        # If one rectangle is on left side of other
+        if(self.ll.x >= rectB.ur.y or rectB.ll.x >= self.ur.y):
+            return False
+
+        # If one rectangle is above other
+        if(self.ur.y <= rectB.ll.y or rectB.ur.y <= self.ll.y):
+            return False
+
+        return True
+
+    def union(self, rectB: Rect) -> Rect:
+        ll = Point(min(self.ll.x, rectB.ll.x),
+                    min(self.ll.y, rectB.ll.y))
+        ur = Point(max(self.ur.x, rectB.ur.x),
+                    max(self.ur.y, rectB.ur.y))
+        return Rect(ll, ur)
+
+    def toList(self) -> list:
+        return [self.ll.x, self.ll.y, self.ur.x, self.ur.y]
+        
+class QuadPoints:
+    """
+    From PDF spec:
+    An array of 8 x n numbers specifying the coordinates of n quadrilaterals
+    in default user space. Each quadrilateral shall encompass a word or group
+    of contiguous words in the text underlying the annotation. The coordinates
+    for each quadrilateral shall be given in the order x1, y1, x2, y2, x3, y3, x4, y4
+    specifying the quadrilateral's four vertices in counterclockwise order 
+    starting with the lower left. The text shall be oriented with respect to the 
+    edge connecting points (x1, y1) with (x2, y2).
+    """
+
+    points: list[Point]
+
+    def __init__(self, points: list[Point]):
+        self.points = points
+
+    def append(self, quadpoints: QuadPoints) -> QuadPoints:
+        return QuadPoints(self.points + quadpoints.points)
+
+    def toList(self) -> list:
+        return [c for p in points for c in p.toList()]
+
+    
+    @staticmethod
+    def fromRect(rect: Rect):
+        """
+        Assumes that the rect is aligned with the text. Will return incorrect
+        results otherwise
+        """
+        # Needs to be in this order to account for rotations applied later?
+        # ll.x, ur.y, ur.x, ur.y, ll.x, ll.y, ur.x, ll.y
+        quadpoints = [Point(rect.ll.x, rect.ur.y),
+                      Point(rect.ur.x, rect.ur.y),
+                      Point(rect.ll.x, rect.ll.y),
+                      Point(rect.ur.x, rect.ll.y)]
+        return QuadPoints(quadpoints)
+
+class Annotation():
+    annotype: str
+    rect: Rect
+    quadpoints: QuadPoints
+
+    def __init__(self, annotype: str, rect: Rect, quadpoints: list = None):
+        self.annotype = annotype
+        self.rect = rect
+        if quadpoints:
+            self.quadpoints = quadpoints
+        else:
+            self.quadpoints = QuadPoints.fromRect(rect)
+
+    def united(self, annot: Annotation) -> Annotation:
+        if self.annotype != annot.annotype:
+            raise Exception("Cannot merge annotations with different types")
+        
+        return Annotation(self.annotype, 
+                            self.rect.union(annot.rect), 
+                            self.quadpoints.append(annot.quadpoints))
+
+    def intersects(self, annot: Annotation) -> bool:
+        return self.rect.intersects(annot.rect)

--- a/rmrl/annotation.py
+++ b/rmrl/annotation.py
@@ -107,14 +107,16 @@ class Annotation():
     annotype: str
     rect: Rect
     quadpoints: QuadPoints
+    contents: str
 
-    def __init__(self, annotype: str, rect: Rect, quadpoints: list = None):
+    def __init__(self, annotype: str, rect: Rect, quadpoints: list = None, contents: str = ""):
         self.annotype = annotype
         self.rect = rect
         if quadpoints:
             self.quadpoints = quadpoints
         else:
             self.quadpoints = QuadPoints.fromRect(rect)
+        self.contents = contents
 
     def united(self, annot: Annotation) -> Annotation:
         if self.annotype != annot.annotype:
@@ -122,7 +124,18 @@ class Annotation():
         
         return Annotation(self.annotype, 
                             self.rect.union(annot.rect), 
-                            self.quadpoints.append(annot.quadpoints))
+                            self.quadpoints.append(annot.quadpoints),
+                            self.contents + annot.contents)
+
+    
+    @staticmethod
+    def union(annotA: Annotation, annotB: Annotation) -> Annotation:
+        if annotA is None:
+            return annotB
+        elif annotB is None:
+            return annotA
+        else:
+            return annotA.united(annotB)
 
     def intersects(self, annot: Annotation) -> bool:
         return self.rect.intersects(annot.rect)

--- a/rmrl/constants.py
+++ b/rmrl/constants.py
@@ -23,3 +23,4 @@ SPOOL_MAX = 10 * 1024 * 1024
 TEMPLATE_PATH = xdg_data_home() / 'rmrl' / 'templates'
 
 VERSION = pkg_resources.get_distribution('rmrl').version
+HIGHLIGHTCOLOR = [1, 0.941177, 0.4]

--- a/rmrl/pens/highlighter.py
+++ b/rmrl/pens/highlighter.py
@@ -19,6 +19,9 @@ from reportlab.graphics.shapes import Rect
 from reportlab.pdfgen.pathobject import PDFPathObject
 from ..annotation import Annotation, Point, Rect, QuadPoints
 
+# In software version 2.7, reMarkable phased out the highlighter pen in favor
+# of a separate .highlights file. This code is likely obsolete and can be removed
+# once we are confident this change is stable
 class HighlighterPen(GenericPen):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/rmrl/pens/highlighter.py
+++ b/rmrl/pens/highlighter.py
@@ -19,9 +19,6 @@ from reportlab.graphics.shapes import Rect
 from reportlab.pdfgen.pathobject import PDFPathObject
 from ..annotation import Annotation, Point, Rect, QuadPoints
 
-# In software version 2.7, reMarkable phased out the highlighter pen in favor
-# of a separate .highlights file. This code is likely obsolete and can be removed
-# once we are confident this change is stable
 class HighlighterPen(GenericPen):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -34,8 +31,8 @@ class HighlighterPen(GenericPen):
         canvas.setLineCap(2)  # Square
         canvas.setLineJoin(1)  # Round
         #canvas.setDash ?? for solid line
-        yellow = (1.000, 0.914, 0.290)
-        canvas.setStrokeColor(yellow, alpha=0.392)
+        white = (1, 1, 1) #color handled by annotation object in PDF
+        canvas.setStrokeColor(white, alpha=0.0)
         canvas.setLineWidth(stroke.width)
 
         path = canvas.beginPath()

--- a/rmrl/pens/highlighter.py
+++ b/rmrl/pens/highlighter.py
@@ -55,9 +55,12 @@ class HighlighterPen(GenericPen):
             width = segment.width
 
             l = [x1-x0, y1-y0]
-            v0 = -l[1]/l[0] 
-            scale = (1+v0**2)**0.5
-            orthogonal = [v0/scale, 1/scale]
+            if l[0] == 0:
+                orthogonal = [1, 0]
+            else:
+                v0 = -l[1]/l[0] 
+                scale = (1+v0**2)**0.5
+                orthogonal = [v0/scale, 1/scale]
 
             xmin = x0-width/2*orthogonal[0]
             ymin = y0-width/2*orthogonal[1]

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -26,7 +26,7 @@ from pdfrw import PdfReader, PdfWriter, PageMerge, PdfDict, PdfArray, PdfName, \
 from reportlab.pdfgen import canvas
 
 from . import document, sources
-from .constants import PDFHEIGHT, PDFWIDTH, PTPERPX, SPOOL_MAX
+from .constants import PDFHEIGHT, PDFWIDTH, PTPERPX, SPOOL_MAX, HIGHLIGHTCOLOR
 from typing import Tuple, List
 
 
@@ -90,7 +90,7 @@ def render(source, *,
     # about 500 pages could use up to 3 GB of RAM. Create them by
     # iteration so they get released by garbage collector.
     changed_pages = []
-    annotations = [] # [pages[Annotations]]
+    annotations = [] # [pages[layers[(layer, [Annotations])]]]
     for i in range(0, len(pages)):
         page = document.DocumentPage(source, pages[i], i)
         if source.exists(page.rmpath):
@@ -398,34 +398,37 @@ def invert_coords(point) -> Tuple[float]:
 
 def apply_annotations(rmpage, page_annot, ocgorderinner):
     # page_annot = layers[(layer, [Annotations])]
-    for a in page_annot:
-        # PDF origin is in bottom-left, so invert all
-        # y-coordinates.
-        author = 'reMarkable' #self.model.device_info['rcuname']
+    for k, layer_a in enumerate(page_annot):
+        layerannots = layer_a[1]
+        for a in layerannots:
+            # PDF origin is in bottom-left, so invert all
+            # y-coordinates.
+            author = 'reMarkable' #self.model.device_info['rcuname']
 
-        x1, y1 = invert_coords(a.rect.ll)
-        x2, y2 = invert_coords(a.rect.ur)
+            x1, y1 = invert_coords(a.rect.ll)
+            x2, y2 = invert_coords(a.rect.ur)
 
-        w = x2-x1
-        h = y1-y2
-        qp = [c for p in map(invert_coords, a.quadpoints.points) for c in p]
-        
-        pdf_a = PdfDict(Type=PdfName('Annot'),
-                        Rect=PdfArray([x1, y1, x2, y2]),
-                        QuadPoints=PdfArray(qp),
-                        Contents=a.contents,
-                        T=author,
-                        ANN='pdfmark',
-                        Subtype=PdfName(a.annotype),
-                        P=rmpage)
-        # Set to indirect because it makes a cleaner PDF
-        # output.
-        pdf_a.indirect = True
-        if ocgorderinner:
-            pdf_a.OC = ocgorderinner[k]
-        if not '/Annots' in rmpage:
-            rmpage.Annots = PdfArray()
-        rmpage.Annots.append(pdf_a)
+            w = x2-x1
+            h = y1-y2
+            qp = [c for p in map(invert_coords, a.quadpoints.points) for c in p]
+            
+            pdf_a = PdfDict(Type=PdfName('Annot'),
+                            Rect=PdfArray([x1, y1, x2, y2]),
+                            QuadPoints=PdfArray(qp),
+                            C=PdfArray(HIGHLIGHTCOLOR),
+                            Contents=a.contents,
+                            T=author,
+                            ANN='pdfmark',
+                            Subtype=PdfName(a.annotype),
+                            P=rmpage)
+            # Set to indirect because it makes a cleaner PDF
+            # output.
+            pdf_a.indirect = True
+            if ocgorderinner:
+                pdf_a.OC = ocgorderinner[k]
+            if not '/Annots' in rmpage:
+                rmpage.Annots = PdfArray()
+            rmpage.Annots.append(pdf_a)
 
 
 def merge_pages(basepage, rmpage, changed_page, expand_pages):


### PR DESCRIPTION
Implements the PDF annotation spec for highlights, including QuadPoints which are used by many utilities to extract the underlying text. Tested and working with a range of sample PDFs on Windows 10 Home, OS build 19042.867
