### PR TITLE
Allow alternate colors for the pens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
+colour = "^0.1.5"
 pdfrw = "^0.4"
 reportlab = "^3.5.59"
 svglib = "^1.0.1"

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -35,6 +35,7 @@ def main():
     parser.add_argument('--only-annotated', action='store_true', help="Only render pages with annotations.")
     parser.add_argument('--black', default='black', help='Color for "black" pen.')
     parser.add_argument('--white', default='white', help='Color for "white" pen.')
+    parser.add_argument('--gray', '--grey', default=None, help='Color for "gray" pen.')
     parser.add_argument('--version', action='version', version=VERSION)
     args = parser.parse_args()
 
@@ -53,7 +54,8 @@ def main():
                         expand_pages=not args.no_expand,
                         only_annotated=args.only_annotated,
                         black=args.black,
-                        white=args.white)
+                        white=args.white,
+                        gray=args.gray)
         fout.write(stream.read())
         fout.close()
         return 0

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -22,7 +22,7 @@ import zipfile
 from colour import Color
 
 from . import render
-from .constants import VERSION
+from .constants import VERSION, HIGHLIGHT_DEFAULT_COLOR
 from .render import InvalidColor
 from .sources import ZipSource
 
@@ -36,6 +36,7 @@ def main():
     parser.add_argument('--black', default='black', help='Color for "black" pen.')
     parser.add_argument('--white', default='white', help='Color for "white" pen.')
     parser.add_argument('--gray', '--grey', default=None, help='Color for "gray" pen.')
+    parser.add_argument('--highlight', '--hilight', '--hl', default=HIGHLIGHT_DEFAULT_COLOR, help='Color for the highlighter.')
     parser.add_argument('--version', action='version', version=VERSION)
     args = parser.parse_args()
 
@@ -55,7 +56,8 @@ def main():
                         only_annotated=args.only_annotated,
                         black=args.black,
                         white=args.white,
-                        gray=args.gray)
+                        gray=args.gray,
+                        highlight=args.highlight)
         fout.write(stream.read())
         fout.close()
         return 0

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -19,6 +19,8 @@ import re
 import sys
 import zipfile
 
+from colour import Color
+
 from . import render
 from .constants import VERSION
 from .sources import ZipSource
@@ -60,10 +62,7 @@ def main():
     return 0
 
 def parse_color(hex_string):
-    color_int = int(hex_string[1:], 16)
-    return (color_int // 65536 / 255,
-            color_int // 256 % 256 / 255,
-            color_int % 256 / 255)
+    return Color(hex_string)
     
 if __name__ == '__main__':
     sys.exit(main())

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -30,8 +30,8 @@ def main():
     parser.add_argument('--alpha', default=0.3, help="Opacity for template background (0 for no background).")
     parser.add_argument('--no-expand', action='store_true', help="Don't expand pages to margins on device.")
     parser.add_argument('--only-annotated', action='store_true', help="Only render pages with annotations.")
-    parser.add_argument('--black', default='#000000', help="Color for \"black\" pen, in hex notation (#RRGGBB).")
-    parser.add_argument('--white', default='#FFFFFF', help="Color for \"white\" pen, in hex notation (#RRGGBB).")
+    parser.add_argument('--black', default='#000000', help='Color for "black" pen, in hex notation (#RRGGBB).')
+    parser.add_argument('--white', default='#FFFFFF', help='Color for "white" pen, in hex notation (#RRGGBB).')
     parser.add_argument('--version', action='version', version=VERSION)
     args = parser.parse_args()
 

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -18,8 +18,6 @@ import io
 import sys
 import zipfile
 
-from colour import Color
-
 from . import render
 from .constants import VERSION, HIGHLIGHT_DEFAULT_COLOR
 from .render import InvalidColor

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -15,7 +15,6 @@
 
 import argparse
 import io
-import re
 import sys
 import zipfile
 

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -55,14 +55,11 @@ def main():
                     template_alpha=float(args.alpha),
                     expand_pages=not args.no_expand,
                     only_annotated=args.only_annotated,
-                    black=parse_color(args.black),
-                    white=parse_color(args.white))
+                    black=args.black,
+                    white=args.white)
     fout.write(stream.read())
     fout.close()
     return 0
 
-def parse_color(hex_string):
-    return Color(hex_string)
-    
 if __name__ == '__main__':
     sys.exit(main())

--- a/rmrl/__main__.py
+++ b/rmrl/__main__.py
@@ -27,7 +27,8 @@ from .render import InvalidColor
 from .sources import ZipSource
 
 def main():
-    parser = argparse.ArgumentParser(description="Render a PDF file from a Remarkable document.")
+    parser = argparse.ArgumentParser(description="Render a PDF file from a Remarkable document.",
+                                     epilog='The colors may be specified as hex strings ("#AABBCC", "#ABC") or well-known names ("black", "red").  If no gray color is given, the program will use an average of the white and black colors.  A fixed amount of transparency will be applied to the color given for the highlighter.')
     parser.add_argument('input', help="Filename of zip file, or root-level unpacked file of document.  Use '-' to read zip file from stdin.")
     parser.add_argument('output', nargs='?', default='', help="Filename where PDF file should be written.  Omit to write to stdout.")
     parser.add_argument('--alpha', default=0.3, help="Opacity for template background (0 for no background).")

--- a/rmrl/constants.py
+++ b/rmrl/constants.py
@@ -23,3 +23,6 @@ SPOOL_MAX = 10 * 1024 * 1024
 TEMPLATE_PATH = xdg_data_home() / 'rmrl' / 'templates'
 
 VERSION = pkg_resources.get_distribution('rmrl').version
+
+HIGHLIGHT_DEFAULT_COLOR = '#FFE949'
+HIGHLIGHT_ALPHA = 0.392

--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -161,6 +161,7 @@ class DocumentPageLayer:
             colors.black.rgb,
             colors.gray.rgb,
             colors.white.rgb,
+            colors.highlight.rgb,
         ]
 
         # Set this from the calling func
@@ -230,6 +231,10 @@ class DocumentPageLayer:
             if penclass is None:
                 log.error("Unknown pen code %d" % pen)
                 penclass = pens.GenericPen
+
+            # Hack to get the right color for the highlighter.
+            if penclass == pens.HighlighterPen:
+                color = -1
 
             qpen = penclass(vector=vector,
                             layer=self,

--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -18,8 +18,6 @@ import gc
 import json
 import logging
 
-from colour import Color
-
 from reportlab.graphics import renderPDF
 from svglib.svglib import svg2rlg
 
@@ -31,12 +29,11 @@ log = logging.getLogger(__name__)
 
 class DocumentPage:
     # A single page in a document
-    def __init__(self, source, pid, pagenum, black=Color('black'), white=Color('white')):
+    def __init__(self, source, pid, pagenum, colors):
         # Page 0 is the first page!
         self.source = source
         self.num = pagenum
-        self.black = black
-        self.white = white
+        self.colors = colors
 
         # On disk, these files are named by a UUID
         self.rmpath = f'{{ID}}/{pid}.rm'
@@ -107,7 +104,7 @@ class DocumentPage:
             except:
                 name = 'Layer ' + str(i + 1)
 
-            layer = DocumentPageLayer(self, name=name, black=self.black, white=self.white)
+            layer = DocumentPageLayer(self, name=name, colors=self.colors)
             layer.strokes = layerstrokes
             self.layers.append(layer)
 
@@ -156,15 +153,14 @@ class DocumentPage:
 class DocumentPageLayer:
     pen_widths = []
 
-    def __init__(self, page, name=None, black=Color('black'), white=('white')):
+    def __init__(self, page, colors, name=None):
         self.page = page
         self.name = name
 
-        gray = list(black.range_to(white, 3))[1]
         self.colors = [
-            black.rgb,
-            gray.rgb,
-            white.rgb,
+            colors.black.rgb,
+            colors.gray.rgb,
+            colors.white.rgb,
         ]
 
         # Set this from the calling func

--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -29,10 +29,12 @@ log = logging.getLogger(__name__)
 
 class DocumentPage:
     # A single page in a document
-    def __init__(self, source, pid, pagenum):
+    def __init__(self, source, pid, pagenum, black=(0, 0, 0), white=(1, 1, 1)):
         # Page 0 is the first page!
         self.source = source
         self.num = pagenum
+        self.black = black
+        self.white = white
 
         # On disk, these files are named by a UUID
         self.rmpath = f'{{ID}}/{pid}.rm'
@@ -103,7 +105,7 @@ class DocumentPage:
             except:
                 name = 'Layer ' + str(i + 1)
 
-            layer = DocumentPageLayer(self, name=name)
+            layer = DocumentPageLayer(self, name=name, black=self.black, white=self.white)
             layer.strokes = layerstrokes
             self.layers.append(layer)
 
@@ -152,7 +154,7 @@ class DocumentPage:
 class DocumentPageLayer:
     pen_widths = []
 
-    def __init__(self, page, name=None):
+    def __init__(self, page, name=None, black=(0, 0, 0), white=(1, 1, 1)):
         self.page = page
         self.name = name
 
@@ -160,9 +162,9 @@ class DocumentPageLayer:
             #QSettings().value('pane/notebooks/export_pdf_blackink'),
             #QSettings().value('pane/notebooks/export_pdf_grayink'),
             #QSettings().value('pane/notebooks/export_pdf_whiteink')
-            (0, 0, 0),
-            (0.5, 0.5, 0.5),
-            (1, 1, 1)
+            black,
+            [(b + w) / 2 for b, w in zip(black, white)],
+            white,
         ]
 
         # Set this from the calling func

--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -18,6 +18,8 @@ import gc
 import json
 import logging
 
+from colour import Color
+
 from reportlab.graphics import renderPDF
 from svglib.svglib import svg2rlg
 
@@ -29,7 +31,7 @@ log = logging.getLogger(__name__)
 
 class DocumentPage:
     # A single page in a document
-    def __init__(self, source, pid, pagenum, black=(0, 0, 0), white=(1, 1, 1)):
+    def __init__(self, source, pid, pagenum, black=Color('black'), white=Color('white')):
         # Page 0 is the first page!
         self.source = source
         self.num = pagenum
@@ -154,17 +156,15 @@ class DocumentPage:
 class DocumentPageLayer:
     pen_widths = []
 
-    def __init__(self, page, name=None, black=(0, 0, 0), white=(1, 1, 1)):
+    def __init__(self, page, name=None, black=Color('black'), white=('white')):
         self.page = page
         self.name = name
 
+        gray = list(black.range_to(white, 3))[1]
         self.colors = [
-            #QSettings().value('pane/notebooks/export_pdf_blackink'),
-            #QSettings().value('pane/notebooks/export_pdf_grayink'),
-            #QSettings().value('pane/notebooks/export_pdf_whiteink')
-            black,
-            [(b + w) / 2 for b, w in zip(black, white)],
-            white,
+            black.rgb,
+            gray.rgb,
+            white.rgb,
         ]
 
         # Set this from the calling func

--- a/rmrl/pens/highlighter.py
+++ b/rmrl/pens/highlighter.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from ..constants import HIGHLIGHT_ALPHA
 from .generic import GenericPen
 
 class HighlighterPen(GenericPen):
@@ -28,7 +29,7 @@ class HighlighterPen(GenericPen):
         canvas.setLineCap(2)  # Square
         canvas.setLineJoin(1)  # Round
         #canvas.setDash ?? for solid line
-        canvas.setStrokeColor((1.000, 0.914, 0.290), alpha=0.392)
+        canvas.setStrokeColor(self.color, alpha=HIGHLIGHT_ALPHA)
         canvas.setLineWidth(stroke.width)
 
         path = canvas.beginPath()

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import json
 import re
 
+from colour import Color
+
 from pdfrw import PdfReader, PdfWriter, PageMerge, PdfDict, PdfArray, PdfName, \
     IndirectPdfDict, uncompress, compress
 
@@ -36,10 +38,9 @@ def render(source, *,
            expand_pages=True,
            template_alpha=0.3,
            only_annotated=False,
-           black=(0, 0, 0),
-           white=(1, 1, 1)):
-    """
-    Render a source document as a PDF file.
+           black=Color('black'),
+           white=Color('white')):
+    """Render a source document as a PDF file.
 
     source: The reMarkable document to be rendered.  This may be
               - A filename or pathlib.Path to a zip file containing the
@@ -61,10 +62,10 @@ def render(source, *,
                     makes the templates invisible, 1 makes them fully dark.
     only_annotated: Boolean value (default False) indicating whether only
                     pages with annotations should be output.
-    black: A tuple of three values (red, green, and blue; 0.0-1.0) giving
-           the color to use as "black" in the document.  Default: (0, 0, 0)
-    white: A tuple of three values (red, green, and blue; 0.0-1.0) giving
-            the color to use as "white" in the document.  Default: (1, 1, 1)
+    black: A colour.Color object giving the color to use as "black" in the
+           document.  Default: Color('black')
+    white: A colour.Color object giving the color to use as "white" in the
+           document.  Default: Color('white')
     """
 
     vector=True  # TODO: Different rendering styles

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -36,6 +36,11 @@ log = logging.getLogger(__name__)
 
 Colors = namedtuple('Colors', ['black', 'white', 'gray'])
 
+class InvalidColor(Exception):
+    """Raised when an invalid string is passed as a color."""
+    pass
+
+
 def render(source, *,
            progress_cb=lambda x: None,
            expand_pages=True,
@@ -191,10 +196,17 @@ def render(source, *,
 
 
 def parse_colors(black, white):
-    black_color = Color(black)
-    white_color = Color(white)
+    black_color = parse_color(black, 'black')
+    white_color = parse_color(white, 'white')
     gray_color = list(black_color.range_to(white_color, 3))[1]
     return Colors(black=black_color, white=white_color, gray=gray_color)
+
+
+def parse_color(color_string, name):
+    try:
+        return Color(color_string)
+    except Exception as e:
+        raise InvalidColor('"{}" color was passed an invalid string: {}'.format(name, str(e)))
 
 
 def do_apply_ocg(basepage, rmpage, i, uses_base_pdf, ocgprop, annotations):

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -35,7 +35,9 @@ def render(source, *,
            progress_cb=lambda x: None,
            expand_pages=True,
            template_alpha=0.3,
-           only_annotated=False):
+           only_annotated=False,
+           black=(0, 0, 0),
+           white=(1, 1, 1)):
     """
     Render a source document as a PDF file.
 
@@ -59,6 +61,10 @@ def render(source, *,
                     makes the templates invisible, 1 makes them fully dark.
     only_annotated: Boolean value (default False) indicating whether only
                     pages with annotations should be output.
+    black: A tuple of three values (red, green, and blue; 0.0-1.0) giving
+           the color to use as "black" in the document.  Default: (0, 0, 0)
+    white: A tuple of three values (red, green, and blue; 0.0-1.0) giving
+            the color to use as "white" in the document.  Default: (1, 1, 1)
     """
 
     vector=True  # TODO: Different rendering styles
@@ -89,7 +95,7 @@ def render(source, *,
     changed_pages = []
     annotations = []
     for i in range(0, len(pages)):
-        page = document.DocumentPage(source, pages[i], i)
+        page = document.DocumentPage(source, pages[i], i, black=black, white=white)
         if source.exists(page.rmpath):
             changed_pages.append(i)
         page.render_to_painter(pdf_canvas, vector, template_alpha)

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -47,7 +47,8 @@ def render(source, *,
            template_alpha=0.3,
            only_annotated=False,
            black='black',
-           white='white'):
+           white='white',
+           gray=None):
     """Render a source document as a PDF file.
 
     source: The reMarkable document to be rendered.  This may be
@@ -74,10 +75,12 @@ def render(source, *,
            Can be a color name or a hex string.  Default: 'black'
     white: A string giving the color to use as "white" in the document.
            See `black` parameter for format.  Default: 'white'
+    gray: A string giving the color to use as "gray" in the document.
+          See `black` parameter for format.  Default: None, which means to
+          pick an average between the "white" and "black" values.
     """
 
-    # TODO: Error handling
-    colors = parse_colors(black, white)
+    colors = parse_colors(black, white, gray)
     
     vector=True  # TODO: Different rendering styles
     source = sources.get_source(source)
@@ -195,10 +198,24 @@ def render(source, *,
     return stream
 
 
-def parse_colors(black, white):
+def parse_colors(black, white, gray):
     black_color = parse_color(black, 'black')
     white_color = parse_color(white, 'white')
-    gray_color = list(black_color.range_to(white_color, 3))[1]
+
+    if gray is not None:
+        # Use the explicit gray value.
+        gray_color = parse_color(gray, 'gray')
+    elif black_color.saturation == 0 or white_color.saturation == 0:
+        # One or the other of the color endpoints is a shade of gray (or
+        # white or black).  Use average in RGB space.  This keeps the hue
+        # from the saturated endpoint and just lets the other endpoint
+        # either darken or lighten it.
+        gray_color = Color(rgb=((b + w) / 2 for b, w in zip(black_color.rgb, white_color.rgb)))
+    else:
+        # Both "black" and "white" have color elements to them.  Use
+        # Color.range_to, which more or less averages in HSL space.
+        gray_color = list(black_color.range_to(white_color, 3))[1]
+
     return Colors(black=black_color, white=white_color, gray=gray_color)
 
 


### PR DESCRIPTION
This adds `render()` and command line parameters to specify the colors that should be used for the "black" and "white" pen colors.  These can be used to, for example, have annotations in red or blue lines to distinguish from the content being annotated.

The default colors are, of course, actual black and white.  The gray pen is always a 50/50 mix of the black and white pens in the RGB color space.