### PR TITLE
Look for base page dimensions in parent of parent in merge_pages

### DIFF
--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -439,9 +439,13 @@ def merge_pages(basepage, rmpage, changed_page, expand_pages):
     # MediaBox, so one must be taken from the parent. The
     # rM adds a bit to the width AND the height on this
     # file.
-    bpage_box = list(map(float, basepage.CropBox
-                                or basepage.MediaBox
-                                or basepage.Parent.MediaBox))
+    # Sometimes the direct parent does not have a MediaBox.
+    # In this situation, look one extra level above.
+    box_data = basepage.CropBox or basepage.MediaBox or basepage.Parent.MediaBox
+    if not box_data and hasattr(basepage.Parent,'Parent'):
+        box_data = basepage.Parent.Parent.MediaBox
+
+    bpage_box = list(map(float, box_data))
 
     # Fix any malformed PDF that has a CropBox extending outside of
     # the MediaBox, by limiting the area to the intersection.

--- a/rmrl/render.py
+++ b/rmrl/render.py
@@ -445,6 +445,10 @@ def merge_pages(basepage, rmpage, changed_page, expand_pages):
     if not box_data and hasattr(basepage.Parent,'Parent'):
         box_data = basepage.Parent.Parent.MediaBox
 
+    # If we still can't find it, raise an exception that describes the problem
+    if not box_data:
+        raise TypeError("Could not find the dimensions of the base PDF page.")
+
     bpage_box = list(map(float, box_data))
 
     # Fix any malformed PDF that has a CropBox extending outside of


### PR DESCRIPTION
Hi rschroll,

I'm using your library in my project and it's very useful, thanks!

This PR fixes a small issue I encountered when running this library on a few of my PDFs. I can tell by your existing comments that finding the base page dimensions is a bit of a pain point. I was able to resolve a majority of error cases I was seeing by looking for the dimensions in the parent of the parent if necessary.

If it still can't find them, I throw an exception that describes what's going on, to avoid the less-than-helpful "'NoneType' object is not iterable" that it's throwing currently.