### PR TITLE
Bugfix template selection

### DIFF
--- a/rmrl/document.py
+++ b/rmrl/document.py
@@ -61,7 +61,7 @@ class DocumentPage:
             # rM won't save the page template for later pages. In this
             # case, just take the last-available page template, which
             # is usually 'Blank'.
-            template_name = template_names[max(self.num, len(template_names) - 1)]
+            template_name = template_names[min(self.num, len(template_names) - 1)]
             template_path = TEMPLATE_PATH / f'{template_name}.svg'
             if template_name != 'Blank' and template_path.exists():
                 self.template = str(template_path)


### PR DESCRIPTION
During initialization of `DocumentPage` instances, a bug caused rmrl to always render the template of the notebook's last page. The bugfix is trivial since this was only a mix-up (`max` instead of `min`).

For more context (if needed) - consider the inline documentation prior to the culprit line:
https://github.com/rschroll/rmrl/blob/89b5cc38ef45251b96bd3d1c3618429b6b46db92/rmrl/document.py#L60-L64

In such cases, `len(template_names)` would be *less than* `self.num`. Access with `max` would then raise an `IndexError`.  
For all other exports (where `self.num` is always less than `len(template_names)`), this line will *always* select the last entry within `template_names`. 